### PR TITLE
Add integration test for blog endpoint

### DIFF
--- a/BlogApp.Api/Program.cs
+++ b/BlogApp.Api/Program.cs
@@ -68,3 +68,6 @@ app.UseAuthorization();
 app.MapControllers();
 
 app.Run();
+
+// Required for integration testing
+public partial class Program { }

--- a/BlogApp.IntegrationTests/BlogApp.IntegrationTests.csproj
+++ b/BlogApp.IntegrationTests/BlogApp.IntegrationTests.csproj
@@ -9,10 +9,19 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.11" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\BlogApp.Core\BlogApp.Core.csproj" />
+    <ProjectReference Include="..\BlogApp.Api\BlogApp.Api.csproj" />
   </ItemGroup>
 
 </Project>

--- a/BlogApp.IntegrationTests/BlogEndpointTests.cs
+++ b/BlogApp.IntegrationTests/BlogEndpointTests.cs
@@ -1,0 +1,46 @@
+using BlogApp.Api.Controllers;
+using BlogApp.Core.Services;
+using BlogApp.Domain.Entities;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using System.Security.Claims;
+using Xunit;
+
+namespace BlogApp.IntegrationTests
+{
+    public class BlogEndpointTests
+    {
+        private readonly TestSettings _settings;
+
+        public BlogEndpointTests()
+        {
+            _settings = TestServicesConfiguration.ConfigureInMemoryDatabaseAndServices();
+        }
+
+        [Fact]
+        public async Task GetTotal_ReturnsOk()
+        {
+            // Arrange
+            var blogService = _settings.ServiceProvider.GetRequiredService<IBlogService>();
+            var commentService = _settings.ServiceProvider.GetRequiredService<ICommentService>();
+            var userManager = _settings.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+            var controller = new BlogController(blogService, commentService, userManager);
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "test") }, "Test"))
+                }
+            };
+
+            // Act
+            var result = await controller.Total();
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(StatusCodes.Status200OK, okResult.StatusCode);
+        }
+    }
+}

--- a/BlogApp.IntegrationTests/TestServicesConfiguration.cs
+++ b/BlogApp.IntegrationTests/TestServicesConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿using BlogApp.Core.Context;
 using BlogApp.Core.Services;
 using BlogApp.Domain.Entities;
+using System;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
@@ -53,6 +54,26 @@ namespace BlogApp.IntegrationTests
                 DatabaseName = databaseName,
                 ServiceProvider = serviceProvider,
                 ConnectionString = connectionString
+            };
+        }
+
+        public static TestSettings ConfigureInMemoryDatabaseAndServices()
+        {
+            var services = new ServiceCollection();
+            var configuration = new ConfigurationBuilder().AddInMemoryCollection().Build();
+
+            services.AddDbContext<IAppDbContext, AppDbContext>(options =>
+                options.UseInMemoryDatabase($"InMemoryDb_{Guid.NewGuid()}"));
+
+            services = InjectServices(services, configuration);
+            services = InjectApplicationUser(services);
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            return new TestSettings
+            {
+                ServiceProvider = serviceProvider,
+                ConnectionString = "InMemory"
             };
         }
 


### PR DESCRIPTION
## Summary
- add integration test project dependencies and reference to API
- support in-memory test configuration
- expose Program class for integration testing
- verify blog total endpoint returns 200

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6841c5e1d41c83319c30ca1e1b2edcbb